### PR TITLE
MacFUSE が最新のMacBookで正常に読み込めない問題に対応

### DIFF
--- a/web/sshfs.html
+++ b/web/sshfs.html
@@ -197,10 +197,9 @@ $(function(){
   </p>
   
   <p>
-    まず初めに，MacFUSEをインストールする．
-    <a href="http://code.google.com/p/macfuse/downloads/list">
-      MacFUSEのダウンロードページ</a>から，
-      最新のMacFUSE（本資料作成時点では2.0.3.2）をダウンロードし，インストールする．
+	  まず初めに，MacFUSEをインストールする．
+	  上記のWebサイトからダウンロードできるMacFUSEには起動できない不具合が存在するため，<a href="http://www.offthehill.org/wp-content/uploads/2010/12/macfuse-core-10.5-2.1.9.zip">不具合修正バージョン (2.1.9) をダウンロード</a>する．
+	  ダウンロードしたファイルを展開し，中の <span class="bold red">MacFUSE Core.pkg</span> をダブルクリックするとインストールが開始されるので，インストールする．
   </p>
   <img src="images/macfuse-install.png" alt="macfuse-install" width="600" />
   <br /><br />


### PR DESCRIPTION
最新のMacBook(Pro)デフォルト起動カーネルが64bitになっているため，MacFUSEが正常に読み込めない問題に対応しました．野良ビルドではありますが修正されたリンクからダウンロードしたMacFUSEで32bit,64bit版 Snow Leopard で起動可能なことを確認してあります．
