### PR TITLE
タグ -> 要素

### DIFF
--- a/web/character_encoding.html
+++ b/web/character_encoding.html
@@ -303,7 +303,7 @@
 </p>
 
 <p>
-  ブラウザは通常HTMLファイルのheadタグ中に書かれたmetaタグのcharset属性を参考に
+  ブラウザは通常HTMLファイルのhead要素中に書かれたmeta要素のcharset属性を参考に
   文字コードを判別する．
 </p>
   <pre class="brush: xml">


### PR DESCRIPTION
HTML 開始タグ, 内容, HTML 終了タグ、の3つが揃って初めて HTML 要素が構成されるのであり、タグとは「<html ********>」や「</ html>」に過ぎないので、HTML タグ (HTML 開始タグまたは HTML 終了タグ) そのものには meta (等の内容) は含まれません。
書き間違いだと思うので、修正していただけると幸いです。